### PR TITLE
Add cnpg 18.0 to versions matrix

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -7,6 +7,8 @@ cnpg:
   - "16.10"
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
   - "17.6"
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  - "18.0"
 vectorchord:
   # renovate: datasource=github-releases depName=tensorchord/VectorChord
   - "0.5.3"


### PR DESCRIPTION
The 'regular' 18-0.5.3 image is already released at https://github.com/tensorchord/VectorChord/pkgs/container/vchord-postgres/527350537?tag=pg18-v0.5.3

Let's do the same for the cnpg version